### PR TITLE
允许使用`resizable=0`参数禁用窗口缩放

### DIFF
--- a/emulator/Chipset/CPUControl.cpp
+++ b/emulator/Chipset/CPUControl.cpp
@@ -4,7 +4,7 @@
 #include "Chipset.hpp"
 #include "MMU.hpp"
 
-#include "../Gui/ui.hpp"
+#include "../Gui/Ui.hpp"
 namespace casioemu
 {
 	// * Control Register Access Instructions

--- a/emulator/Chipset/CPUPushPop.cpp
+++ b/emulator/Chipset/CPUPushPop.cpp
@@ -4,7 +4,7 @@
 #include "Chipset.hpp"
 #include "MMU.hpp"
 
-#include "../Gui/ui.hpp"
+#include "../Gui/Ui.hpp"
 
 namespace casioemu
 {

--- a/emulator/Chipset/Chipset.cpp
+++ b/emulator/Chipset/Chipset.cpp
@@ -15,7 +15,7 @@
 #include "../Peripheral/Timer.hpp"
 #include "../Peripheral/BCDCalc.hpp"
 
-#include "../Gui/ui.hpp"
+#include "../Gui/Ui.hpp"
 
 #include <fstream>
 #include <algorithm>

--- a/emulator/Emulator.cpp
+++ b/emulator/Emulator.cpp
@@ -78,7 +78,8 @@ namespace casioemu
 			SDL_WINDOWPOS_UNDEFINED,
 			width, height,
 			SDL_WINDOW_SHOWN |
-			(SDL_WINDOW_RESIZABLE)
+//			(SDL_WINDOW_RESIZABLE)
+            (IsResizable() ? SDL_WINDOW_RESIZABLE : 0)
 		);
 		if (!window)
 			PANIC("SDL_CreateWindow failed: %s\n", SDL_GetError());
@@ -518,4 +519,11 @@ namespace casioemu
 				waiting.front().notify_one(); // the notify_one must be called while m is locked, otherwise the condition variable might be destroyed (as noted on https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one)
 		}
 	}
+
+    bool Emulator::IsResizable() {
+        if (argv_map.find("resizable") != argv_map.end() && argv_map["resizable"] == "0") {
+            return false;
+        }
+        return true;
+    }
 }

--- a/emulator/Emulator.hpp
+++ b/emulator/Emulator.hpp
@@ -123,6 +123,12 @@ namespace casioemu
 		ModelInfo GetModelInfo(std::string key);
 		std::string GetModelFilePath(std::string relative_path);
 
+        /**
+         * We make the UI resizable by default
+         * You can also specify a negative config parameter to disable this: resizable=0
+         */
+        bool IsResizable();
+
 		friend class ModelInfo;
 		friend class CPU;
 		friend class MMU;

--- a/emulator/Peripheral/BatteryBackedRAM.cpp
+++ b/emulator/Peripheral/BatteryBackedRAM.cpp
@@ -5,7 +5,7 @@
 #include "../Emulator.hpp"
 #include "../Chipset/Chipset.hpp"
 #include "../Logger.hpp"
-#include "../Gui/ui.hpp"
+#include "../Gui/Ui.hpp"
 #include <fstream>
 #include <cstring>
 

--- a/emulator/casioemu.cpp
+++ b/emulator/casioemu.cpp
@@ -179,12 +179,12 @@ int main(int argc, char *argv[])
 					emulator.Shutdown();
 					break;
 				case SDL_WINDOWEVENT_RESIZED:
-					// if (!argv_map.count("resizable"))
-					// {
-					// 	// Normally, in this case, the window manager should not
-					// 	// send resized event, but some still does (such as xmonad)
-					// 	break;
-					// }
+					 if (!emulator.IsResizable())
+					 {
+					 	// Normally, in this case, the window manager should not
+					 	// send resized event, but some still does (such as xmonad)
+					 	break;
+					 }
 					ImGui_ImplSDL2_ProcessEvent(&event);
 					if(event.window.windowID == SDL_GetWindowID(emulator.window)){
 					emulator.WindowResize(event.window.data1, event.window.data2);

--- a/emulator/casioemu.cpp
+++ b/emulator/casioemu.cpp
@@ -1,6 +1,6 @@
 #include "Config.hpp"
 #include "Gui/imgui_impl_sdl2.h"
-#include "Gui/ui.hpp"
+#include "Gui/Ui.hpp"
 
 #include <SDL.h>
 #include <SDL_image.h>


### PR DESCRIPTION
在平铺式窗口管理器上，默认resizable会让模拟器直接全屏，一切东西铺满屏幕；如果手动指定了`width` `height`参数，又会让旁边留黑边，得手动按个全屏切换快捷键（比如i3wm是$mod+Shift+space），体验不好。

原版模拟器默认不开启resizable，不会出现这个问题，故现在恢复`resizable`的配置。默认还是可缩放的，只不过能加反向参数来禁用。