### PR TITLE
内存显示标记：添加配置文件改动监测。

### DIFF
--- a/emulator/Gui/Ui.cpp
+++ b/emulator/Gui/Ui.cpp
@@ -88,6 +88,12 @@ void DebugUi::PaintUi(){
 CodeViewer* DebugUi::code_viewer = nullptr;
 MemoryEditor::OptionalMarkedSpans* DebugUi::MARKED_SPANS = nullptr;
 
+void DebugUi::UpdateMarkedSpans(const MemoryEditor::OptionalMarkedSpans &spans) {
+    delete MARKED_SPANS;
+    auto leaked = new std::optional(spans);
+    MARKED_SPANS = leaked;
+}
+
 void gui_loop(){
     
 }

--- a/emulator/Gui/Ui.hpp
+++ b/emulator/Gui/Ui.hpp
@@ -34,11 +34,7 @@ public:
     static CodeViewer* code_viewer;
     static MemoryEditor::OptionalMarkedSpans *MARKED_SPANS;
 
-    static void UpdateMarkedSpans(const MemoryEditor::OptionalMarkedSpans &spans) {
-        delete MARKED_SPANS;
-        auto leaked = new std::optional(spans);
-        MARKED_SPANS = leaked;
-    }
+    static void UpdateMarkedSpans(const MemoryEditor::OptionalMarkedSpans &spans);
 
     DebugUi(casioemu::Emulator* emu);
 

--- a/emulator/casioemu.cpp
+++ b/emulator/casioemu.cpp
@@ -272,7 +272,7 @@ void StartMemSpansConfigWatcherThread(const std::string &path) {
             if (FileSystem::exists(path)) {
                 auto mtime = FileSystem::mtime_ms(path);
                 if (mtime != last_mtime) {
-                    DebugUi::UpdateMarkedSpans(casioemu::parseColoredSpansConfig(path));
+                    DebugUi::UpdateMarkedSpans(casioemu::ParseColoredSpansConfig(path));
                     last_mtime = mtime;
                 }
             } else {

--- a/emulator/utils.cpp
+++ b/emulator/utils.cpp
@@ -12,7 +12,7 @@ const char *casioemu::Exception::what() const noexcept {
 
 casioemu::Exception::Exception(std::string _msg) : msg(std::move(_msg)) {}
 
-std::vector<MemoryEditor::MarkedSpan> casioemu::parseColoredSpansConfig(const std::string &path) {
+std::vector<MemoryEditor::MarkedSpan> casioemu::ParseColoredSpansConfig(const std::string &path) {
     auto result = std::vector<MemoryEditor::MarkedSpan>();
 
     std::ifstream file(path);

--- a/emulator/utils.cpp
+++ b/emulator/utils.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "utils.h"
+#include <unistd.h>
+#include <sys/stat.h>
 
 const char *casioemu::Exception::what() const noexcept {
     return msg.c_str();
@@ -67,4 +69,22 @@ bool casioemu::starts_with(const std::string &str, const std::string &prefix) {
         return false;
     }
     return str.substr(0, prefix.length()) == prefix;
+}
+
+bool casioemu::FileSystem::exists(const std::string &path) {
+    return access(path.c_str(), F_OK) == 0;
+}
+
+timespec casioemu::FileSystem::mtime(const std::string &path) {
+    struct stat stat_r{};
+    if (stat(path.c_str(), &stat_r) != 0) {
+        perror("stat");
+        return {};
+    }
+    return stat_r.st_mtim;
+}
+
+uint64_t casioemu::FileSystem::mtime_ms(const std::string &path) {
+    const timespec &ts = FileSystem::mtime(path);
+    return (uint64_t) ts.tv_sec * 1000 + (uint64_t) ts.tv_nsec / 1000000;
 }

--- a/emulator/utils.h
+++ b/emulator/utils.h
@@ -24,7 +24,7 @@ namespace casioemu {
 
     bool starts_with(const std::string &str, const std::string &prefix);
 
-    std::vector<MemoryEditor::MarkedSpan> parseColoredSpansConfig(const std::string &path);
+    std::vector<MemoryEditor::MarkedSpan> ParseColoredSpansConfig(const std::string &path);
 
     class FileSystem {
     public:

--- a/emulator/utils.h
+++ b/emulator/utils.h
@@ -25,6 +25,15 @@ namespace casioemu {
     bool starts_with(const std::string &str, const std::string &prefix);
 
     std::vector<MemoryEditor::MarkedSpan> parseColoredSpansConfig(const std::string &path);
+
+    class FileSystem {
+    public:
+        static bool exists(const std::string &path);
+
+        static timespec mtime(const std::string &path);
+
+        static uint64_t mtime_ms(const std::string &path);
+    };
 }
 
 #endif //CASIOEMUX_UTILS_H


### PR DESCRIPTION
这是一个 #11 跟进。

使用了C库函数来判断文件存在和获取文件修改时间。

目前使用的是定期轮询来检测文件改动，是有专门检测文件系统改动的方法的，但这个小功能
没必要写平台相关代码，而且对单个文件的性能影响是微小的。

因为最开始的想法就是能在用的时候随便标记，能在UI上动态选中+标记颜色什么的，但那个太难了，配置文件法只是一种折中的方案。或者这个改动watcher可以作为一个可选功能，不过性能上我认为是不用担心一点的。