### PR TITLE
Injector: make "load ROP from string" more flexible

### DIFF
--- a/emulator/Emulator.hpp
+++ b/emulator/Emulator.hpp
@@ -15,6 +15,10 @@
 #include "Data/ModelInfo.hpp"
 #include "Data/SpriteInfo.hpp"
 
+#define MEM_EDIT_BASE_ADDR 0xD000
+#define MEM_EDIT_MEM_SIZE 0x2100
+#define LABEL_INPUT_BUF 0xd180
+
 namespace casioemu
 {
 	class Chipset;

--- a/emulator/Gui/Ui.hpp
+++ b/emulator/Gui/Ui.hpp
@@ -7,9 +7,6 @@
 #include "WatchWindow.hpp"
 #include "Injector.hpp"
 
-#define MEM_EDIT_BASE_ADDR 0xD000
-#define MEM_EDIT_MEM_SIZE 0x2100
-
 // #include "../Emulator.hpp"
 // #include "CodeViewer.hpp"
 // int test_gui();


### PR DESCRIPTION
- make hex case-insensitive
- ignore all non-hex characters (like whitespaces)
- support comments (;)

A sample ROP string:
```
; 二、三行拼字示例：（~和剪刀符号各一行）
; mode: 110an，线性/线性模式
; 在经过smart_strcpy后，ER2会变为输入区（0xd180）
7E7E7E7E7E7E7E7E7E7E7E7E7E7E7E7E7E ;17个“~”
E7E7E7E7E7E7E7E7E7E7E7E7E7E7E7E7E7 ;17个剪刀
A82121FE ; (2:21A8) POP ER0 + Return，将会：0x3010 -> ER0即0x10 -> R0 让R0为0x10
1030
AE212230 ; (2:21AE) 偏移16（0x10）像素（第二行）打印ER2，此时ER2会后移17字节
A82121FE ; (2:21A8) POP ER0 + Return，会让R0为0x20
20FD
5C202248 ; (2:205C) 偏移32（0x20）像素（第三行）打印ER2
; 2:205C函数返回后，会冻结计算器。
```